### PR TITLE
Add scipy to requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,3 +4,4 @@ pandas
 pyserial
 sensiml>=2022.3.0
 fsspec
+scipy


### PR DESCRIPTION
I needed to install `scipy` to get generate_audio_dcli.py to work.